### PR TITLE
Adding an argument to choose which answer will skip to the next song + fix scoreboard

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,9 +25,10 @@ export class MusicQuizCommand extends Command {
                     default: 10
                 },
                 {
-                    key: 'onlyThis',
+                    key: 'only',
                     prompt: 'Only this answer is required; artist, title or both',
                     type: 'string',
+                    oneOf: ['artist', 'title', 'both'],
                     default: 'both'
                 }
             ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,6 +29,7 @@ export class MusicQuizCommand extends Command {
                     prompt: 'Only this answer is required; artist, title or both',
                     type: 'string',
                     default: 'both'
+                }
             ]
         })
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,7 +23,12 @@ export class MusicQuizCommand extends Command {
                     prompt: 'How many songs the quiz will contain',
                     type: 'string',
                     default: 10
-                }
+                },
+                {
+                    key: 'onlyThis',
+                    prompt: 'Only this answer is required; artist, title or both',
+                    type: 'string',
+                    default: 'both'
             ]
         })
     }

--- a/src/music-quiz.ts
+++ b/src/music-quiz.ts
@@ -212,10 +212,8 @@ export class MusicQuiz {
                     position = ':first_place:'
                 } else if (index === 1) {
                     position = ':second_place:'
-                } else if (index === 3) {
+                } else if (index === 2) {
                     position = ':third_place:'
-                } else if (index > 3) {
-                    position = index.'.'
                 }
 
                 return `${position} <@!${member.id}> ${this.scores[member.id] || 0} points`

--- a/src/music-quiz.ts
+++ b/src/music-quiz.ts
@@ -77,8 +77,16 @@ export class MusicQuiz {
     }
 
     async startPlaying() {
-        this.titleGuessed = false
-        this.artistGuessed = false
+        
+        if (this.arguments.onlyThis.toLowerCase() === 'artist') {
+            this.titleGuessed = true
+        } else if (this.arguments.onlyThis.toLowerCase() === 'title') {
+            this.artistGuessed = true
+        } else if {
+            this.titleGuessed = false
+            this.artistGuessed = false 
+        }
+        
         const song = this.songs[this.currentSong]
 
         const link = await this.findSong(song)
@@ -206,6 +214,8 @@ export class MusicQuiz {
                     position = ':second_place:'
                 } else if (index === 3) {
                     position = ':third_place:'
+                } else if (index > 3) {
+                    position = index.'.'
                 }
 
                 return `${position} <@!${member.id}> ${this.scores[member.id] || 0} points`

--- a/src/types/quiz-args.ts
+++ b/src/types/quiz-args.ts
@@ -1,4 +1,5 @@
 export interface QuizArgs {
     playlist: string
     songs: string
+    onlyThis: string
 }


### PR DESCRIPTION
I think it could be useful for Disney music quiz because we don't know the singer or to add more difficulty.
It's still able to count points if they find the artist and the title. It'll be extra points (to be change if you don't like)
I fixed also the scoreboard for more than 3 players.